### PR TITLE
[feat] RCP for trusted OIDC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,7 @@ jobs:
             --disable-rollback \
             --no-fail-on-empty-changeset \
             --no-progressbar \
+            --parameter-overrides "pGithubOrganization=${{ github.repository_owner }}" \
             --role-arn ${{ vars.CF_ROLE_ARN }} \
             --stack-name ${{ env.STACK_NAME }} \
             --s3-bucket ${{ vars.ARTIFACT_BUCKET }} \

--- a/template.yml
+++ b/template.yml
@@ -44,6 +44,9 @@ Parameters:
     Type: String
     Description: Organizational Unit (OU) for security accounts
     Default: Security_Prod
+  pGithubOrganization:
+    Type: String
+    Description: GitHub Organization or User
 
 Conditions:
   cHasInstanceArn: !Not [!Equals [!Ref pInstanceArn, ""]]
@@ -200,6 +203,37 @@ Resources:
         - !GetAtt rOrganization.RootId
       Type: RESOURCE_CONTROL_POLICY
   
+  rTrustedOIDCTenantsPolicy:
+    Type: "AWS::Organizations::Policy"
+    DependsOn: rActivateCustomResource
+    Properties:
+      Content:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: EnforceTrustedOIDCTenants
+            Effect: Deny
+            Principal: "*"
+            Action: "sts:AssumeRoleWithWebIdentity"
+            Resource: "*"
+            Condition:
+              StringNotLikeIfExists:
+                "token.actions.githubusercontent.com:sub": !Sub "repo:${pGithubOrganization}/*"
+                "aws:ResourceTag/dp:exclude:identity": "true"
+              "Null":
+                "token.actions.githubusercontent.com:sub": "false"
+      Description: Limit access to trusted OIDC identity providers
+      Name: TrustedOIDCProvidersPolicy
+      Tags:
+        - Key: "aws-cloudformation:stack-name"
+          Value: !Ref "AWS::StackName"
+        - Key: "aws-cloudformation:stack-id"
+          Value: !Ref "AWS::StackId"
+        - Key: "aws-cloudformation:logical-id"
+          Value: rTrustedOIDCTenantsPolicy
+      TargetIds:
+        - !GetAtt rOrganization.RootId
+      Type: RESOURCE_CONTROL_POLICY
+
   rRootDeclarativePolicyEC2:
     Type: "AWS::Organizations::Policy"
     DependsOn: rActivateCustomResource


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Add a new RCP to limit trusted OIDC access to the GitHub organization from which the templates are deployed

https://github.com/aws-samples/resource-control-policy-examples/blob/main/Limit-access-to-trusted-OIDC-identity-providers/GitHub-Actions.json

https://github.com/aws-samples/data-perimeter-policy-examples/blob/main/resource_control_policies/identity_perimeter_rcp.json#L39


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
