### PR TITLE
[feat] Add new policy type for SecurityHub

### DIFF
--- a/src/activation_lambda/index.py
+++ b/src/activation_lambda/index.py
@@ -77,6 +77,7 @@ policy_types = [
     "BACKUP_POLICY",
     "CHATBOT_POLICY",
     "TAG_POLICY",
+    "SECURITYHUB_POLICY",
 ]
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Support new Organizations policy type - https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_security_hub.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
